### PR TITLE
Add alacritty and tmux extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,10 +324,12 @@
 <!-- extras:start -->
 | Tool | Extra |
 |:--:|:--:|
+| [Alacritty](https://github.com/alacritty/alacritty) | [extras/alacritty](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/alacritty) |
 | [Fzf](https://github.com/junegunn/fzf) | [extras/fzf](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/fzf) |
 | [Ghostty](https://github.com/ghostty-org/ghostty) | [extras/ghostty](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/ghostty) |
 | [Kitty](https://sw.kovidgoyal.net/kitty/conf.html) | [extras/kitty](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/kitty) |
 | [Lazygit](https://github.com/jesseduffield/lazygit) | [extras/lazygit](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/lazygit) |
+| [Tmux](https://github.com/tmux/tmux/wiki) | [extras/tmux](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/tmux) |
 | [Vimium](https://vimium.github.io/) | [extras/vimium](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/vimium) |
 | [WezTerm](https://wezfurlong.org/wezterm/config/files.html) | [extras/wezterm](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/wezterm) |
 | [Windows Terminal](https://aka.ms/terminal-documentation) | [extras/windows_terminal](https://github.com/oonamo/ef-themes.nvim/tree/main/extras/windows_terminal) |

--- a/extras/alacritty/ef-arbutus.toml
+++ b/extras/alacritty/ef-arbutus.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#ffead8'
+foreground   = '#393330'
+
+# Normal colors
+[colors.normal]
+black     = '#ffead8'
+red       = '#b0000f'
+green     = '#007000'
+yellow    = '#906200'
+blue      = '#375cc6'
+magenta   = '#a23ea4'
+cyan      = '#3f69af'
+white     = '#393330'
+
+# Bright colors
+[colors.bright]
+black     = '#f0d8cf'
+red       = '#ff8f88'
+green     = '#96df80'
+yellow    = '#efbf00'
+blue      = '#afbeff'
+magenta   = '#bf9fff'
+cyan      = '#88d4f0'
+white     = '#6e678f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b44405'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#8f2f30'

--- a/extras/alacritty/ef-autumn.toml
+++ b/extras/alacritty/ef-autumn.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#0f0e06'
+foreground   = '#cfbcba'
+
+# Normal colors
+[colors.normal]
+black     = '#0f0e06'
+red       = '#ef656a'
+green     = '#2fa526'
+yellow    = '#c48702'
+blue      = '#379cf6'
+magenta   = '#d570af'
+cyan      = '#4fb0cf'
+white     = '#cfbcba'
+
+# Bright colors
+[colors.bright]
+black     = '#26211d'
+red       = '#b02930'
+green     = '#4a7000'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#804fd5'
+cyan      = '#2270be'
+white     = '#887c8a'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d0730f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#df7f7f'

--- a/extras/alacritty/ef-bio.toml
+++ b/extras/alacritty/ef-bio.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#111111'
+foreground   = '#cfdfd5'
+
+# Normal colors
+[colors.normal]
+black     = '#111111'
+red       = '#ef6560'
+green     = '#3fb83f'
+yellow    = '#d4aa02'
+blue      = '#37aff6'
+magenta   = '#d38faf'
+cyan      = '#6fc5ef'
+white     = '#cfdfd5'
+
+# Bright colors
+[colors.bright]
+black     = '#222522'
+red       = '#b02930'
+green     = '#407430'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#a04fc5'
+cyan      = '#2270be'
+white     = '#808f80'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#e09a0f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#d56f72'

--- a/extras/alacritty/ef-cherie.toml
+++ b/extras/alacritty/ef-cherie.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#190a0f'
+foreground   = '#d3cfcf'
+
+# Normal colors
+[colors.normal]
+black     = '#190a0f'
+red       = '#ff7359'
+green     = '#60b444'
+yellow    = '#e5b76f'
+blue      = '#8fa5f6'
+magenta   = '#ef80bf'
+cyan      = '#8fbaef'
+white     = '#d3cfcf'
+
+# Bright colors
+[colors.bright]
+black     = '#291f26'
+red       = '#b02930'
+green     = '#2a7140'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#804fd5'
+cyan      = '#2270cf'
+white     = '#808898'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#ea9955'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#e47f72'

--- a/extras/alacritty/ef-cyprus.toml
+++ b/extras/alacritty/ef-cyprus.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fcf7ef'
+foreground   = '#242521'
+
+# Normal colors
+[colors.normal]
+black     = '#fcf7ef'
+red       = '#9f0d0f'
+green     = '#006f00'
+yellow    = '#a7601f'
+blue      = '#375cc6'
+magenta   = '#9a456f'
+cyan      = '#1f70af'
+white     = '#242521'
+
+# Bright colors
+[colors.bright]
+black     = '#f0ece0'
+red       = '#ff8f88'
+green     = '#96df80'
+yellow    = '#efbf00'
+blue      = '#cfceff'
+magenta   = '#df9fff'
+cyan      = '#88cfd0'
+white     = '#59786f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#bf4400'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#b05350'

--- a/extras/alacritty/ef-dark.toml
+++ b/extras/alacritty/ef-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#000000'
+foreground   = '#d0d0d0'
+
+# Normal colors
+[colors.normal]
+black     = '#000000'
+red       = '#ef6560'
+green     = '#0faa26'
+yellow    = '#bf9032'
+blue      = '#3f95f6'
+magenta   = '#d369af'
+cyan      = '#4fbaef'
+white     = '#d0d0d0'
+
+# Bright colors
+[colors.bright]
+black     = '#1a1a1a'
+red       = '#b02930'
+green     = '#337133'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#804fdd'
+cyan      = '#2270cf'
+white     = '#857f8f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d1843f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#d56f72'

--- a/extras/alacritty/ef-day.toml
+++ b/extras/alacritty/ef-day.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fff5ea'
+foreground   = '#584141'
+
+# Normal colors
+[colors.normal]
+black     = '#fff5ea'
+red       = '#ba2d2f'
+green     = '#007a0a'
+yellow    = '#a45a22'
+blue      = '#375cc6'
+magenta   = '#ca3e54'
+cyan      = '#3f60af'
+white     = '#584141'
+
+# Bright colors
+[colors.bright]
+black     = '#f2e9db'
+red       = '#ff8f88'
+green     = '#96df80'
+yellow    = '#efbf00'
+blue      = '#cfceff'
+magenta   = '#df9fff'
+cyan      = '#88cfd0'
+white     = '#63728f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b75515'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#b05350'

--- a/extras/alacritty/ef-deuteranopia-dark.toml
+++ b/extras/alacritty/ef-deuteranopia-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#000a1f'
+foreground   = '#ddddee'
+
+# Normal colors
+[colors.normal]
+black     = '#000a1f'
+red       = '#cf8560'
+green     = '#3faa26'
+yellow    = '#aa9f32'
+blue      = '#3f90f0'
+magenta   = '#b379bf'
+cyan      = '#5faaef'
+white     = '#ddddee'
+
+# Bright colors
+[colors.bright]
+black     = '#121f34'
+red       = '#8d7f00'
+green     = '#afcf20'
+yellow    = '#5f5f00'
+blue      = '#266fd0'
+magenta   = '#6f60c0'
+cyan      = '#007fae'
+white     = '#7f8797'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#cfaf00'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#b57f82'

--- a/extras/alacritty/ef-deuteranopia-light.toml
+++ b/extras/alacritty/ef-deuteranopia-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#f5f5ff'
+foreground   = '#1a1a2f'
+
+# Normal colors
+[colors.normal]
+black     = '#f5f5ff'
+red       = '#d3303a'
+green     = '#217a3c'
+yellow    = '#805d00'
+blue      = '#375cd8'
+magenta   = '#ba35af'
+cyan      = '#1f6fbf'
+white     = '#1a1a2f'
+
+# Bright colors
+[colors.bright]
+black     = '#e8e8ea'
+red       = '#cac200'
+green     = '#9aaf80'
+yellow    = '#fac200'
+blue      = '#cbcfff'
+magenta   = '#3fbfff'
+cyan      = '#98e8ff'
+white     = '#70627f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#965000'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#a04852'

--- a/extras/alacritty/ef-dream.toml
+++ b/extras/alacritty/ef-dream.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#232025'
+foreground   = '#efd5c5'
+
+# Normal colors
+[colors.normal]
+black     = '#232025'
+red       = '#ff6f6f'
+green     = '#51b04f'
+yellow    = '#c0b24f'
+blue      = '#57b0ff'
+magenta   = '#ffaacf'
+cyan      = '#6fb3c0'
+white     = '#efd5c5'
+
+# Bright colors
+[colors.bright]
+black     = '#322f34'
+red       = '#a02f50'
+green     = '#30682f'
+yellow    = '#8f665f'
+blue      = '#4f509f'
+magenta   = '#885997'
+cyan      = '#0280b9'
+white     = '#8f8886'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d09950'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#f3a0a0'

--- a/extras/alacritty/ef-duo-dark.toml
+++ b/extras/alacritty/ef-duo-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#070019'
+foreground   = '#d0d0d0'
+
+# Normal colors
+[colors.normal]
+black     = '#070019'
+red       = '#ef656a'
+green     = '#1fa526'
+yellow    = '#c48702'
+blue      = '#379cf6'
+magenta   = '#d369af'
+cyan      = '#5faaef'
+white     = '#d0d0d0'
+
+# Bright colors
+[colors.bright]
+black     = '#1d1a26'
+red       = '#cd2f30'
+green     = '#407720'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#b04fcf'
+cyan      = '#2270be'
+white     = '#857f8f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d0730f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#d08f72'

--- a/extras/alacritty/ef-duo-light.toml
+++ b/extras/alacritty/ef-duo-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fff8f0'
+foreground   = '#222222'
+
+# Normal colors
+[colors.normal]
+black     = '#fff8f0'
+red       = '#cc3333'
+green     = '#217a3c'
+yellow    = '#8a5d00'
+blue      = '#375cd8'
+magenta   = '#ba35af'
+cyan      = '#1f6fbf'
+white     = '#222222'
+
+# Bright colors
+[colors.bright]
+black     = '#f6ece8'
+red       = '#ff8f88'
+green     = '#8adf80'
+yellow    = '#fac200'
+blue      = '#cbcfff'
+magenta   = '#df8fff'
+cyan      = '#88c8ff'
+white     = '#63728f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#9f4a00'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#a2403f'

--- a/extras/alacritty/ef-eagle.toml
+++ b/extras/alacritty/ef-eagle.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#f1ecd0'
+foreground   = '#231a1f'
+
+# Normal colors
+[colors.normal]
+black     = '#f1ecd0'
+red       = '#882000'
+green     = '#226022'
+yellow    = '#6b4500'
+blue      = '#113384'
+magenta   = '#822478'
+cyan      = '#125a7f'
+white     = '#231a1f'
+
+# Bright colors
+[colors.bright]
+black     = '#e4dbc0'
+red       = '#f08f88'
+green     = '#96df8f'
+yellow    = '#efbf00'
+blue      = '#cfceff'
+magenta   = '#dfafff'
+cyan      = '#a0ddd0'
+white     = '#685f53'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#843300'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#702f1f'

--- a/extras/alacritty/ef-elea-dark.toml
+++ b/extras/alacritty/ef-elea-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#222524'
+foreground   = '#eaf2ef'
+
+# Normal colors
+[colors.normal]
+black     = '#222524'
+red       = '#ff656a'
+green     = '#7fc87f'
+yellow    = '#cac85f'
+blue      = '#57aff6'
+magenta   = '#f59acf'
+cyan      = '#6fcfd2'
+white     = '#eaf2ef'
+
+# Bright colors
+[colors.bright]
+black     = '#303332'
+red       = '#bd1f30'
+green     = '#408420'
+yellow    = '#847020'
+blue      = '#2f5f9f'
+magenta   = '#b05fcf'
+cyan      = '#028099'
+white     = '#969faf'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#e0b02f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#eba8a8'

--- a/extras/alacritty/ef-elea-light.toml
+++ b/extras/alacritty/ef-elea-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#edf5e2'
+foreground   = '#221321'
+
+# Normal colors
+[colors.normal]
+black     = '#edf5e2'
+red       = '#c3303a'
+green     = '#00601f'
+yellow    = '#9a501f'
+blue      = '#375cc6'
+magenta   = '#80308f'
+cyan      = '#1f70af'
+white     = '#221321'
+
+# Bright colors
+[colors.bright]
+black     = '#e3e9d6'
+red       = '#ff8f88'
+green     = '#a6df80'
+yellow    = '#efbf00'
+blue      = '#cfceff'
+magenta   = '#df9fff'
+cyan      = '#88cbdc'
+white     = '#676470'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b04300'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#894852'

--- a/extras/alacritty/ef-false.toml
+++ b/extras/alacritty/ef-false.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#292d3e'
+foreground   = '#eeffff'
+
+# Normal colors
+[colors.normal]
+black     = '#292d3e'
+red       = '#ff5f59'
+green     = '#44bc44'
+yellow    = '#d0bc00'
+blue      = '#2fafff'
+magenta   = '#feacd0'
+cyan      = '#00d3d0'
+white     = '#eeffff'
+
+# Bright colors
+[colors.bright]
+black     = '#1d2235'
+red       = '#9d1f1f'
+green     = '#2f822f'
+yellow    = '#7a6100'
+blue      = '#1640b0'
+magenta   = '#7030af'
+cyan      = '#2277ae'
+white     = 'gray50'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#fec43f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#ff8f80'

--- a/extras/alacritty/ef-frost.toml
+++ b/extras/alacritty/ef-frost.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fcffff'
+foreground   = '#232323'
+
+# Normal colors
+[colors.normal]
+black     = '#fcffff'
+red       = '#c42d2f'
+green     = '#008a00'
+yellow    = '#aa6100'
+blue      = '#004fc0'
+magenta   = '#aa44c5'
+cyan      = '#1f6fbf'
+white     = '#232323'
+
+# Bright colors
+[colors.bright]
+black     = '#eaefef'
+red       = '#ff8f88'
+green     = '#8adf90'
+yellow    = '#fac200'
+blue      = '#cbcfff'
+magenta   = '#df8fff'
+cyan      = '#88c8ff'
+white     = '#66657f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b6532f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#9a4366'

--- a/extras/alacritty/ef-kassio.toml
+++ b/extras/alacritty/ef-kassio.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fff7f7'
+foreground   = '#201f36'
+
+# Normal colors
+[colors.normal]
+black     = '#fff7f7'
+red       = '#b00234'
+green     = '#217a3c'
+yellow    = '#9a6012'
+blue      = '#3c3bbe'
+magenta   = '#a01f64'
+cyan      = '#2f5f9f'
+white     = '#201f36'
+
+# Bright colors
+[colors.bright]
+black     = '#efe7e7'
+red       = '#ff8f88'
+green     = '#8adf80'
+yellow    = '#fac200'
+blue      = '#cbcfff'
+magenta   = '#df8fff'
+cyan      = '#88c8ff'
+white     = '#776f79'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b6530f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#af3f5f'

--- a/extras/alacritty/ef-light.toml
+++ b/extras/alacritty/ef-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#ffffff'
+foreground   = '#202020'
+
+# Normal colors
+[colors.normal]
+black     = '#ffffff'
+red       = '#d3303a'
+green     = '#217a3c'
+yellow    = '#a45f22'
+blue      = '#3740cf'
+magenta   = '#ba35af'
+cyan      = '#1f6fbf'
+white     = '#202020'
+
+# Bright colors
+[colors.bright]
+black     = '#efefef'
+red       = '#ff8f88'
+green     = '#9adf90'
+yellow    = '#fac200'
+blue      = '#cbcfff'
+magenta   = '#df8fff'
+cyan      = '#88c8ff'
+white     = '#68759f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b6532f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#c24552'

--- a/extras/alacritty/ef-maris-dark.toml
+++ b/extras/alacritty/ef-maris-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#131c2b'
+foreground   = '#eaedef'
+
+# Normal colors
+[colors.normal]
+black     = '#131c2b'
+red       = '#ff6f6f'
+green     = '#41bf4f'
+yellow    = '#d0d24f'
+blue      = '#57b0ff'
+magenta   = '#f59acf'
+cyan      = '#2fd0db'
+white     = '#eaedef'
+
+# Bright colors
+[colors.bright]
+black     = '#1d2c39'
+red       = '#bd1f30'
+green     = '#107840'
+yellow    = '#847020'
+blue      = '#2f5f9f'
+magenta   = '#b05fcf'
+cyan      = '#0280b9'
+white     = '#969faf'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#f0c060'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#eaa4a4'

--- a/extras/alacritty/ef-maris-light.toml
+++ b/extras/alacritty/ef-maris-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#edf4f8'
+foreground   = '#151a27'
+
+# Normal colors
+[colors.normal]
+black     = '#edf4f8'
+red       = '#c3303a'
+green     = '#007010'
+yellow    = '#805a1f'
+blue      = '#375cc6'
+magenta   = '#80308f'
+cyan      = '#1f66af'
+white     = '#151a27'
+
+# Bright colors
+[colors.bright]
+black     = '#e0e7ef'
+red       = '#ff8f88'
+green     = '#96df80'
+yellow    = '#efbf00'
+blue      = '#cfceff'
+magenta   = '#df9fff'
+cyan      = '#88cfd0'
+white     = '#676470'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#8b4400'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#8b4052'

--- a/extras/alacritty/ef-melissa-dark.toml
+++ b/extras/alacritty/ef-melissa-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#352718'
+foreground   = '#e8e4b1'
+
+# Normal colors
+[colors.normal]
+black     = '#352718'
+red       = '#ff7f7f'
+green     = '#6fd560'
+yellow    = '#e4b53f'
+blue      = '#57aff6'
+magenta   = '#f0aac5'
+cyan      = '#6fcad0'
+white     = '#e8e4b1'
+
+# Bright colors
+[colors.bright]
+black     = '#483426'
+red       = '#b02930'
+green     = '#4a7100'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#a04fc5'
+cyan      = '#2270cf'
+white     = '#90918a'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#ffa21f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#e89a88'

--- a/extras/alacritty/ef-melissa-light.toml
+++ b/extras/alacritty/ef-melissa-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fff6d8'
+foreground   = '#484431'
+
+# Normal colors
+[colors.normal]
+black     = '#fff6d8'
+red       = '#ba2d2f'
+green     = '#007a0a'
+yellow    = '#a26310'
+blue      = '#375cc6'
+magenta   = '#aa3e74'
+cyan      = '#3f60af'
+white     = '#484431'
+
+# Bright colors
+[colors.bright]
+black     = '#f5e9cb'
+red       = '#ff8f88'
+green     = '#96df80'
+yellow    = '#efbf00'
+blue      = '#cfceff'
+magenta   = '#df9fff'
+cyan      = '#88cfd0'
+white     = '#68708a'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#ba5205'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#b05350'

--- a/extras/alacritty/ef-night.toml
+++ b/extras/alacritty/ef-night.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#000e17'
+foreground   = '#afbcbf'
+
+# Normal colors
+[colors.normal]
+black     = '#000e17'
+red       = '#ef656a'
+green     = '#1fa526'
+yellow    = '#c48502'
+blue      = '#379cf6'
+magenta   = '#d570af'
+cyan      = '#4fb0cf'
+white     = '#afbcbf'
+
+# Bright colors
+[colors.bright]
+black     = '#1a202b'
+red       = '#bd1f30'
+green     = '#107440'
+yellow    = '#847020'
+blue      = '#2f5f9f'
+magenta   = '#804fd5'
+cyan      = '#0280b9'
+white     = '#70819f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#e6832f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#d56f72'

--- a/extras/alacritty/ef-owl.toml
+++ b/extras/alacritty/ef-owl.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#292c2f'
+foreground   = '#d0d0d0'
+
+# Normal colors
+[colors.normal]
+black     = '#292c2f'
+red       = '#d67869'
+green     = '#70bb70'
+yellow    = '#c09f6f'
+blue      = '#80a4e0'
+magenta   = '#e5a0ea'
+cyan      = '#8fb8ea'
+white     = '#d0d0d0'
+
+# Bright colors
+[colors.bright]
+black     = '#373b3d'
+red       = '#a02f50'
+green     = '#30682f'
+yellow    = '#8f665f'
+blue      = '#4f509f'
+magenta   = '#885997'
+cyan      = '#4f70aa'
+white     = '#857f8f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d1a45f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#eba0af'

--- a/extras/alacritty/ef-reverie.toml
+++ b/extras/alacritty/ef-reverie.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#f3eddf'
+foreground   = '#4f204f'
+
+# Normal colors
+[colors.normal]
+black     = '#f3eddf'
+red       = '#ba2d2f'
+green     = '#007a0a'
+yellow    = '#87591f'
+blue      = '#375cc6'
+magenta   = '#9f4e74'
+cyan      = '#3060af'
+white     = '#4f204f'
+
+# Bright colors
+[colors.bright]
+black     = '#e5d6d4'
+red       = '#ed899f'
+green     = '#96d080'
+yellow    = '#e2b270'
+blue      = '#c0c0f0'
+magenta   = '#daaaf0'
+cyan      = '#8fc6d0'
+white     = '#6f6877'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#a05900'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#a04650'

--- a/extras/alacritty/ef-rosa.toml
+++ b/extras/alacritty/ef-rosa.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#322023'
+foreground   = '#e4d3e1'
+
+# Normal colors
+[colors.normal]
+black     = '#322023'
+red       = '#ff707f'
+green     = '#5fbb5f'
+yellow    = '#e4c53f'
+blue      = '#57aff6'
+magenta   = '#ffb2d6'
+cyan      = '#5fc0dc'
+white     = '#e4d3e1'
+
+# Bright colors
+[colors.bright]
+black     = '#432e32'
+red       = '#bd1f30'
+green     = '#408420'
+yellow    = '#847020'
+blue      = '#2f5f9f'
+magenta   = '#905fdf'
+cyan      = '#028099'
+white     = '#9d9d9d'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#f2a85f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#e89f84'

--- a/extras/alacritty/ef-spring.toml
+++ b/extras/alacritty/ef-spring.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#f6fff9'
+foreground   = '#34494a'
+
+# Normal colors
+[colors.normal]
+black     = '#f6fff9'
+red       = '#c42d2f'
+green     = '#1a870f'
+yellow    = '#a45f22'
+blue      = '#375cc6'
+magenta   = '#d5206f'
+cyan      = '#1f6fbf'
+white     = '#34494a'
+
+# Bright colors
+[colors.bright]
+black     = '#e8f0f0'
+red       = '#ff8f88'
+green     = '#7fdda0'
+yellow    = '#efcf00'
+blue      = '#afdfff'
+magenta   = '#df8fff'
+cyan      = '#80caf0'
+white     = '#777294'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b6540f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#b64850'

--- a/extras/alacritty/ef-summer.toml
+++ b/extras/alacritty/ef-summer.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fff2f3'
+foreground   = '#4f4073'
+
+# Normal colors
+[colors.normal]
+black     = '#fff2f3'
+red       = '#d3303a'
+green     = '#217a3c'
+yellow    = '#a45f22'
+blue      = '#375ce6'
+magenta   = '#ba35af'
+cyan      = '#1f6fbf'
+white     = '#4f4073'
+
+# Bright colors
+[colors.bright]
+black     = '#f2e4ea'
+red       = '#ff7f88'
+green     = '#86df80'
+yellow    = '#ffc200'
+blue      = '#cbcfff'
+magenta   = '#df8fff'
+cyan      = '#88ccff'
+white     = '#786e74'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b6532f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#c24552'

--- a/extras/alacritty/ef-symbiosis.toml
+++ b/extras/alacritty/ef-symbiosis.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#130911'
+foreground   = '#d0d0d0'
+
+# Normal colors
+[colors.normal]
+black     = '#130911'
+red       = '#ef6360'
+green     = '#0faa26'
+yellow    = '#bf9032'
+blue      = '#3f95f6'
+magenta   = '#d369af'
+cyan      = '#4fbaef'
+white     = '#d0d0d0'
+
+# Bright colors
+[colors.bright]
+black     = '#221920'
+red       = '#b02930'
+green     = '#4a7100'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#804fdf'
+cyan      = '#2270cf'
+white     = '#857f8f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d1843f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#d56f72'

--- a/extras/alacritty/ef-tint.toml
+++ b/extras/alacritty/ef-tint.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#0d0e1c'
+foreground   = '#ffffff'
+
+# Normal colors
+[colors.normal]
+black     = '#0d0e1c'
+red       = '#ff5f59'
+green     = '#44bc44'
+yellow    = '#d0bc00'
+blue      = '#2fafff'
+magenta   = '#feacd0'
+cyan      = '#00d3d0'
+white     = '#ffffff'
+
+# Bright colors
+[colors.bright]
+black     = '#1d2235'
+red       = '#9d1f1f'
+green     = '#2f822f'
+yellow    = '#7a6100'
+blue      = '#1640b0'
+magenta   = '#7030af'
+cyan      = '#2277ae'
+white     = '#989898'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#fec43f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#ff8f80'

--- a/extras/alacritty/ef-trio-dark.toml
+++ b/extras/alacritty/ef-trio-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#160f0f'
+foreground   = '#d8cfd5'
+
+# Normal colors
+[colors.normal]
+black     = '#160f0f'
+red       = '#f48359'
+green     = '#60b444'
+yellow    = '#d4a052'
+blue      = '#7fa5f6'
+magenta   = '#d37faf'
+cyan      = '#8fbaff'
+white     = '#d8cfd5'
+
+# Bright colors
+[colors.bright]
+black     = '#2a2228'
+red       = '#b02930'
+green     = '#2a7140'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#804fd5'
+cyan      = '#2270cf'
+white     = '#908890'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#ef926f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#e07a9a'

--- a/extras/alacritty/ef-trio-light.toml
+++ b/extras/alacritty/ef-trio-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#f8f5ff'
+foreground   = '#4f3363'
+
+# Normal colors
+[colors.normal]
+black     = '#f8f5ff'
+red       = '#c3303a'
+green     = '#057800'
+yellow    = '#a45f22'
+blue      = '#375cd6'
+magenta   = '#ad45ba'
+cyan      = '#1f6fbf'
+white     = '#4f3363'
+
+# Bright colors
+[colors.bright]
+black     = '#ebe7f1'
+red       = '#ff7f88'
+green     = '#7fdda0'
+yellow    = '#ffc200'
+blue      = '#cbcfff'
+magenta   = '#df8fff'
+cyan      = '#88ccff'
+white     = '#786e74'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#b8532f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#a24568'

--- a/extras/alacritty/ef-tritanopia-dark.toml
+++ b/extras/alacritty/ef-tritanopia-dark.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#15050f'
+foreground   = '#dfd0d5'
+
+# Normal colors
+[colors.normal]
+black     = '#15050f'
+red       = '#cf4f5f'
+green     = '#2fa526'
+yellow    = '#c48702'
+blue      = '#379cf6'
+magenta   = '#b0648f'
+cyan      = '#3fafcf'
+white     = '#dfd0d5'
+
+# Bright colors
+[colors.bright]
+black     = '#282026'
+red       = '#aa0010'
+green     = '#5f806f'
+yellow    = '#950f4f'
+blue      = '#165f70'
+magenta   = '#a04f9f'
+cyan      = '#007faa'
+white     = '#908890'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d0730f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#b07f7f'

--- a/extras/alacritty/ef-tritanopia-light.toml
+++ b/extras/alacritty/ef-tritanopia-light.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#fff9f9'
+foreground   = '#1a1a1a'
+
+# Normal colors
+[colors.normal]
+black     = '#fff9f9'
+red       = '#aa0010'
+green     = '#217a3c'
+yellow    = '#805d00'
+blue      = '#375cd8'
+magenta   = '#aa357f'
+cyan      = '#2070af'
+white     = '#1a1a1a'
+
+# Bright colors
+[colors.bright]
+black     = '#efecec'
+red       = '#ffa2a0'
+green     = '#8aefef'
+yellow    = '#ff7f78'
+blue      = '#a8c8ef'
+magenta   = '#e09fc0'
+cyan      = '#7bcfcf'
+white     = '#756275'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#965000'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#92454f'

--- a/extras/alacritty/ef-winter.toml
+++ b/extras/alacritty/ef-winter.toml
@@ -1,0 +1,37 @@
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '#0f0b15'
+foreground   = '#b8c6d5'
+
+# Normal colors
+[colors.normal]
+black     = '#0f0b15'
+red       = '#f47359'
+green     = '#29a444'
+yellow    = '#b58a52'
+blue      = '#3f95f6'
+magenta   = '#d369af'
+cyan      = '#4fbaef'
+white     = '#b8c6d5'
+
+# Bright colors
+[colors.bright]
+black     = '#1d202f'
+red       = '#b02930'
+green     = '#0a7040'
+yellow    = '#8f5040'
+blue      = '#4648d0'
+magenta   = '#a04fc5'
+cyan      = '#2270cf'
+white     = '#807c9f'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '#d1803f'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '#d56f72'

--- a/extras/tmux/ef-arbutus.tmux
+++ b/extras/tmux/ef-arbutus.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#e9a0a0,fg=#40231f
+set-option -g status-left '#[bg=#e9a0a0,fg=#40231f,bold]#{?client_prefix,,  tmux  }#[bg=#007000,fg=#f0d8cf,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#007000,fg=#f0d8cf] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-autumn.tmux
+++ b/extras/tmux/ef-autumn.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#692a12,fg=#feeeca
+set-option -g status-left '#[bg=#692a12,fg=#feeeca,bold]#{?client_prefix,,  tmux  }#[bg=#00b066,fg=#26211d,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#00b066,fg=#26211d] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-bio.tmux
+++ b/extras/tmux/ef-bio.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#00552f,fg=#d0ffe0
+set-option -g status-left '#[bg=#00552f,fg=#d0ffe0,bold]#{?client_prefix,,  tmux  }#[bg=#00c089,fg=#222522,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#00c089,fg=#222522] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-cherie.tmux
+++ b/extras/tmux/ef-cherie.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#771a4f,fg=#ffcfdf
+set-option -g status-left '#[bg=#771a4f,fg=#ffcfdf,bold]#{?client_prefix,,  tmux  }#[bg=#f470df,fg=#291f26,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#f470df,fg=#291f26] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-cyprus.tmux
+++ b/extras/tmux/ef-cyprus.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#c0df6f,fg=#142010
+set-option -g status-left '#[bg=#c0df6f,fg=#142010,bold]#{?client_prefix,,  tmux  }#[bg=#006f00,fg=#f0ece0,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#006f00,fg=#f0ece0] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-dark.tmux
+++ b/extras/tmux/ef-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#2a2a75,fg=#e0e0ff
+set-option -g status-left '#[bg=#2a2a75,fg=#e0e0ff,bold]#{?client_prefix,,  tmux  }#[bg=#3f95f6,fg=#1a1a1a,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#3f95f6,fg=#1a1a1a] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-day.tmux
+++ b/extras/tmux/ef-day.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#ffaf72,fg=#542f38
+set-option -g status-left '#[bg=#ffaf72,fg=#542f38,bold]#{?client_prefix,,  tmux  }#[bg=#ba2d2f,fg=#f2e9db,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#ba2d2f,fg=#f2e9db] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-deuteranopia-dark.tmux
+++ b/extras/tmux/ef-deuteranopia-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#003f8f,fg=#ffffff
+set-option -g status-left '#[bg=#003f8f,fg=#ffffff,bold]#{?client_prefix,,  tmux  }#[bg=#009fff,fg=#121f34,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#009fff,fg=#121f34] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-deuteranopia-light.tmux
+++ b/extras/tmux/ef-deuteranopia-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#99c7ff,fg=#0a0a1f
+set-option -g status-left '#[bg=#99c7ff,fg=#0a0a1f,bold]#{?client_prefix,,  tmux  }#[bg=#065fff,fg=#e8e8ea,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#065fff,fg=#e8e8ea] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-dream.tmux
+++ b/extras/tmux/ef-dream.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#675072,fg=#fedeff
+set-option -g status-left '#[bg=#675072,fg=#fedeff,bold]#{?client_prefix,,  tmux  }#[bg=#deb07a,fg=#322f34,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#deb07a,fg=#322f34] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-duo-dark.tmux
+++ b/extras/tmux/ef-duo-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#352487,fg=#dedeff
+set-option -g status-left '#[bg=#352487,fg=#dedeff,bold]#{?client_prefix,,  tmux  }#[bg=#6f80ff,fg=#1d1a26,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#6f80ff,fg=#1d1a26] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-duo-light.tmux
+++ b/extras/tmux/ef-duo-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#f8cf8f,fg=#111133
+set-option -g status-left '#[bg=#f8cf8f,fg=#111133,bold]#{?client_prefix,,  tmux  }#[bg=#4250ef,fg=#f6ece8,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#4250ef,fg=#f6ece8] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-eagle.tmux
+++ b/extras/tmux/ef-eagle.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#cfab80,fg=#2f1005
+set-option -g status-left '#[bg=#cfab80,fg=#2f1005,bold]#{?client_prefix,,  tmux  }#[bg=#882000,fg=#e4dbc0,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#882000,fg=#e4dbc0] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-elea-dark.tmux
+++ b/extras/tmux/ef-elea-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#35605d,fg=#ecf0ff
+set-option -g status-left '#[bg=#35605d,fg=#ecf0ff,bold]#{?client_prefix,,  tmux  }#[bg=#50cf89,fg=#303332,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#50cf89,fg=#303332] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-elea-light.tmux
+++ b/extras/tmux/ef-elea-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#a5c67f,fg=#142810
+set-option -g status-left '#[bg=#a5c67f,fg=#142810,bold]#{?client_prefix,,  tmux  }#[bg=#007047,fg=#e3e9d6,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#007047,fg=#e3e9d6] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-false.tmux
+++ b/extras/tmux/ef-false.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#232635,fg=#ffffff
+set-option -g status-left '#[bg=#232635,fg=#ffffff,bold]#{?client_prefix,,  tmux  }#[bg=#00bcff,fg=#1d2235,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#00bcff,fg=#1d2235] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-frost.tmux
+++ b/extras/tmux/ef-frost.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#9ad0ff,fg=#051524
+set-option -g status-left '#[bg=#9ad0ff,fg=#051524,bold]#{?client_prefix,,  tmux  }#[bg=#4244ef,fg=#eaefef,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#4244ef,fg=#eaefef] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-kassio.tmux
+++ b/extras/tmux/ef-kassio.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#e0bfba,fg=#151515
+set-option -g status-left '#[bg=#e0bfba,fg=#151515,bold]#{?client_prefix,,  tmux  }#[bg=#3c3bbe,fg=#efe7e7,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#3c3bbe,fg=#efe7e7] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-light.tmux
+++ b/extras/tmux/ef-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#b7c7ff,fg=#151515
+set-option -g status-left '#[bg=#b7c7ff,fg=#151515,bold]#{?client_prefix,,  tmux  }#[bg=#4250ef,fg=#efefef,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#4250ef,fg=#efefef] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-maris-dark.tmux
+++ b/extras/tmux/ef-maris-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#2f527b,fg=#ecf0ff
+set-option -g status-left '#[bg=#2f527b,fg=#ecf0ff,bold]#{?client_prefix,,  tmux  }#[bg=#12b4ff,fg=#1d2c39,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#12b4ff,fg=#1d2c39] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-maris-light.tmux
+++ b/extras/tmux/ef-maris-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#a0c2ef,fg=#142810
+set-option -g status-left '#[bg=#a0c2ef,fg=#142810,bold]#{?client_prefix,,  tmux  }#[bg=#003faf,fg=#e0e7ef,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#003faf,fg=#e0e7ef] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-melissa-dark.tmux
+++ b/extras/tmux/ef-melissa-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#704f00,fg=#f8efd8
+set-option -g status-left '#[bg=#704f00,fg=#f8efd8,bold]#{?client_prefix,,  tmux  }#[bg=#ffa21f,fg=#483426,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#ffa21f,fg=#483426] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-melissa-light.tmux
+++ b/extras/tmux/ef-melissa-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#f3cf72,fg=#403328
+set-option -g status-left '#[bg=#f3cf72,fg=#403328,bold]#{?client_prefix,,  tmux  }#[bg=#ba5205,fg=#f5e9cb,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#ba5205,fg=#f5e9cb] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-night.tmux
+++ b/extras/tmux/ef-night.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#003a7f,fg=#ceeeff
+set-option -g status-left '#[bg=#003a7f,fg=#ceeeff,bold]#{?client_prefix,,  tmux  }#[bg=#029fff,fg=#1a202b,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#029fff,fg=#1a202b] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-owl.tmux
+++ b/extras/tmux/ef-owl.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#5b637e,fg=#dadfe5
+set-option -g status-left '#[bg=#5b637e,fg=#dadfe5,bold]#{?client_prefix,,  tmux  }#[bg=#7ac0b9,fg=#373b3d,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#7ac0b9,fg=#373b3d] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-reverie.tmux
+++ b/extras/tmux/ef-reverie.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#d1b0df,fg=#523044
+set-option -g status-left '#[bg=#d1b0df,fg=#523044,bold]#{?client_prefix,,  tmux  }#[bg=#87591f,fg=#e5d6d4,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#87591f,fg=#e5d6d4] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-rosa.tmux
+++ b/extras/tmux/ef-rosa.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#814558,fg=#e8e5e7
+set-option -g status-left '#[bg=#814558,fg=#e8e5e7,bold]#{?client_prefix,,  tmux  }#[bg=#8ad05a,fg=#432e32,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#8ad05a,fg=#432e32] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-spring.tmux
+++ b/extras/tmux/ef-spring.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#90e8b0,fg=#243228
+set-option -g status-left '#[bg=#90e8b0,fg=#243228,bold]#{?client_prefix,,  tmux  }#[bg=#1a870f,fg=#e8f0f0,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#1a870f,fg=#e8f0f0] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-summer.tmux
+++ b/extras/tmux/ef-summer.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#ffa4dc,fg=#341f58
+set-option -g status-left '#[bg=#ffa4dc,fg=#341f58,bold]#{?client_prefix,,  tmux  }#[bg=#8e44f3,fg=#f2e4ea,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#8e44f3,fg=#f2e4ea] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-symbiosis.tmux
+++ b/extras/tmux/ef-symbiosis.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#583435,fg=#ffe5f0
+set-option -g status-left '#[bg=#583435,fg=#ffe5f0,bold]#{?client_prefix,,  tmux  }#[bg=#4fbaef,fg=#221920,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#4fbaef,fg=#221920] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-tint.tmux
+++ b/extras/tmux/ef-tint.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#484d67,fg=#ffffff
+set-option -g status-left '#[bg=#484d67,fg=#ffffff,bold]#{?client_prefix,,  tmux  }#[bg=#00bcff,fg=#1d2235,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#00bcff,fg=#1d2235] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-trio-dark.tmux
+++ b/extras/tmux/ef-trio-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#6a294f,fg=#ffdfdf
+set-option -g status-left '#[bg=#6a294f,fg=#ffdfdf,bold]#{?client_prefix,,  tmux  }#[bg=#e772df,fg=#2a2228,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#e772df,fg=#2a2228] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-trio-light.tmux
+++ b/extras/tmux/ef-trio-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#ddb4ff,fg=#241f48
+set-option -g status-left '#[bg=#ddb4ff,fg=#241f48,bold]#{?client_prefix,,  tmux  }#[bg=#c035aa,fg=#ebe7f1,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#c035aa,fg=#ebe7f1] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-tritanopia-dark.tmux
+++ b/extras/tmux/ef-tritanopia-dark.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#671822,fg=#ffffff
+set-option -g status-left '#[bg=#671822,fg=#ffffff,bold]#{?client_prefix,,  tmux  }#[bg=#3fafcf,fg=#282026,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#3fafcf,fg=#282026] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-tritanopia-light.tmux
+++ b/extras/tmux/ef-tritanopia-light.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#ff99aa,fg=#1a0a0f
+set-option -g status-left '#[bg=#ff99aa,fg=#1a0a0f,bold]#{?client_prefix,,  tmux  }#[bg=#2070af,fg=#efecec,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#2070af,fg=#efecec] #I:#W#{?window_zoomed_flag,  , }'

--- a/extras/tmux/ef-winter.tmux
+++ b/extras/tmux/ef-winter.tmux
@@ -1,0 +1,9 @@
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=#5f1f5f,fg=#dedeff
+set-option -g status-left '#[bg=#5f1f5f,fg=#dedeff,bold]#{?client_prefix,,  tmux  }#[bg=#af85ea,fg=#1d202f,bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=#af85ea,fg=#1d202f] #I:#W#{?window_zoomed_flag,  , }'

--- a/lua/ef-themes/extras/alacritty.lua
+++ b/lua/ef-themes/extras/alacritty.lua
@@ -1,0 +1,45 @@
+local M = {}
+
+function M.template()
+	return [=[
+# Modus Themes for Alacritty
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/alacritty.lua
+
+# Default colors
+[colors.primary]
+background   = '${bg_main}'
+foreground   = '${fg_main}'
+
+# Normal colors
+[colors.normal]
+black     = '${bg_main}'
+red       = '${red}'
+green     = '${green}'
+yellow    = '${yellow}'
+blue      = '${blue}'
+magenta   = '${magenta}'
+cyan      = '${cyan}'
+white     = '${fg_main}'
+
+# Bright colors
+[colors.bright]
+black     = '${bg_dim}'
+red       = '${bg_red_intense}'
+green     = '${bg_green_intense}'
+yellow    = '${bg_yellow_intense}'
+blue      = '${bg_blue_intense}'
+magenta   = '${bg_magenta_intense}'
+cyan      = '${bg_cyan_intense}'
+white     = '${fg_dim}'
+
+[[colors.indexed_colors]]
+index     = 16
+color     = '${yellow_warmer}'
+
+[[colors.indexed_colors]]
+index     = 17
+color     = '${red_faint}'
+]=]
+end
+
+return M

--- a/lua/ef-themes/extras/init.lua
+++ b/lua/ef-themes/extras/init.lua
@@ -1,7 +1,7 @@
 local M = {
   extras = {
     -- aerc = { url = "https://git.sr.ht/~rjarry/aerc", label = "Aerc" },
-    -- alacritty = { ext = "toml", url = "https://github.com/alacritty/alacritty", label = "Alacritty" },
+    alacritty = { ext = "toml", url = "https://github.com/alacritty/alacritty", label = "Alacritty" },
     -- bat = { ext = "tmTheme", url = "https://github.com/sharkdp/bat", label = "Bat" },
     -- delta = { ext = "gitconfig", url = "https://github.com/dandavison/delta", label = "Delta" },
     -- dunst = { ext = "dunstrc", url = "https://dunst-project.org/", label = "Dunst" },
@@ -20,7 +20,7 @@ local M = {
     --   label = "Terminator",
     -- },
     -- tilix = { ext = "json", url = "https://github.com/gnunn1/tilix", label = "Tilix" },
-    -- tmux = { ext = "tmux", url = "https://github.com/tmux/tmux/wiki", label = "Tmux" },
+    tmux = { ext = "tmux", url = "https://github.com/tmux/tmux/wiki", label = "Tmux" },
     lazygit = { ext = "yml", url = "https://github.com/jesseduffield/lazygit", label = "Lazygit" },
     fzf = { ext = "sh", url = "https://github.com/junegunn/fzf", label = "Fzf" },
     ghostty = { ext = "", url = "https://github.com/ghostty-org/ghostty", label = "Ghostty" },

--- a/lua/ef-themes/extras/tmux.lua
+++ b/lua/ef-themes/extras/tmux.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+function M.template()
+	return [[
+# Modus Themes for Tmux
+# Auto generated with https://github.com/oonamo/ef-themes.nvim/blob/master/lua/ef-themes/extras/tmux.lua
+
+set-option -g status-position "bottom"
+set-option -g status-style bg=${bg_mode_line},fg=${fg_mode_line}
+set-option -g status-left '#[bg=${bg_mode_line},fg=${fg_mode_line},bold]#{?client_prefix,,  tmux  }#[bg=${accent_0},fg=${bg_dim},bold]#{?client_prefix,  tmux  ,}'
+set-option -g status-right '#S'
+set-option -g window-status-format ' #I:#W '
+set-option -g window-status-current-format '#[bg=${accent_0},fg=${bg_dim}] #I:#W#{?window_zoomed_flag,  , }'
+]]
+end
+
+return M

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 REPO_OWNER="protesilaos"
 REPO_NAME="ef-themes"


### PR DESCRIPTION
Hello - thank you for this plugin! I was about to make my own before finding this. 

I have adapted https://github.com/miikanissi/modus-themes.nvim/blob/master/lua/modus-themes/extras/alacritty.lua and https://github.com/miikanissi/modus-themes.nvim/blob/master/lua/modus-themes/extras/tmux.lua from the modus-themes.nvim plugin to work with this plugin so that we can generate alacritty and tmux themes. I've only tried out ef-autumn so far with these, but seems to work as expected. 

I also modified the build script to get the env executable from `/usr/bin/env`to make it more portable - especially for us macOS users. 