### PR TITLE
Fix mini.hicolors contrast for light themes

### DIFF
--- a/lua/ef-themes/groups/mini.lua
+++ b/lua/ef-themes/groups/mini.lua
@@ -70,10 +70,10 @@ function M.get(c, opts)
     MiniFilesTitle                = { link      = "FloatTitle" },
     MiniFilesTitleFocused         = { fg        = c.name, bg               = c.bg_dim, bold                 = true },
 
-    MiniHipatternsFixme           = { fg        = c.fg_term_black, bg      = c.err, bold                    = true },
-    MiniHipatternsHack            = { fg        = c.fg_term_black, bg      = c.warning, bold                = true },
-    MiniHipatternsNote            = { fg        = c.fg_term_black, bg      = c.blue, bold                   = true },
-    MiniHipatternsTodo            = { fg        = c.fg_term_black, bg      = c.info, bold                   = true },
+    MiniHipatternsFixme           = { fg        = c.fg_intense,    bg      = c.bg_err, bold                 = true },
+    MiniHipatternsHack            = { fg        = c.fg_intense,    bg      = c.bg_warning, bold             = true },
+    MiniHipatternsNote            = { fg        = c.fg_intense,    bg      = c.bg_blue_intense, bold        = true },
+    MiniHipatternsTodo            = { fg        = c.fg_intense,    bg      = c.bg_info, bold                = true },
 
     MiniIconsAzure                = { fg        = c.blue_warmer },
     MiniIconsBlue                 = { fg        = is_dark and c.blue_faint or c.blue_cooler },


### PR DESCRIPTION
Currently it's using blue/red/etc and black text on top of it. It causes low contrast situation, but there are already defined colors for those situations.  This PR makes use of intense foreground instead of using black verbatim and use `bg_info` instead of `info` etc. I haven't tested all of the themes, but it seems to be fine on ef-spring and ef-bio (which I'm currently using)

<img width="120" height="84" alt="image" src="https://github.com/user-attachments/assets/0de1418b-dcab-4e18-af2d-9ff3ad074f7d" />
<img width="126" height="85" alt="image" src="https://github.com/user-attachments/assets/f4a7fd46-30a0-446a-aceb-437ee136a63c" />
